### PR TITLE
Add attraction detail pages

### DIFF
--- a/app/attraction/[id]/page.tsx
+++ b/app/attraction/[id]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+
+interface Attraction {
+  id: number;
+  name: string;
+  detail: string;
+  coverimage: string;
+  latitude: number;
+  longitude: number;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  const res = await fetch(`https://www.melivecode.com/api/attractions/${params.id}`, {
+    cache: "no-store",
+  });
+  const data = await res.json();
+  const attraction: Attraction = data.attraction;
+  return {
+    title: attraction.name,
+  };
+}
+
+export default async function AttractionDetail({ params }: { params: { id: string } }) {
+  const res = await fetch(`https://www.melivecode.com/api/attractions/${params.id}`, {
+    cache: "no-store",
+  });
+  const data = await res.json();
+  const attraction: Attraction = data.attraction;
+
+  return (
+    <main className="container mx-auto p-6">
+      <div className="max-w-2xl mx-auto">
+        <img
+          src={attraction.coverimage}
+          alt={attraction.name}
+          className="w-full h-64 object-cover rounded-md mb-4"
+        />
+        <h1 className="text-3xl font-bold mb-4">{attraction.name}</h1>
+        <p className="mb-4">{attraction.detail}</p>
+        <p className="text-sm text-gray-600">
+          Latitude: {attraction.latitude}, Longitude: {attraction.longitude}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 interface Attraction {
   id: number;
   name: string;
@@ -18,8 +20,9 @@ export default async function Home() {
       <h1 className="text-3xl font-bold mb-8 text-center">Tourist Attractions</h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {attractions.map((item) => (
-          <div
+          <Link
             key={item.id}
+            href={`/attraction/${item.id}`}
             className="flex flex-col bg-white rounded-lg shadow p-4"
           >
             <img
@@ -29,7 +32,7 @@ export default async function Home() {
             />
             <h2 className="text-lg font-semibold mb-2">{item.name}</h2>
             <p className="text-sm text-gray-600 flex-grow">{item.detail}</p>
-          </div>
+          </Link>
         ))}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- link attraction cards to a new detail page
- fetch and render individual attraction details

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Failed to fetch Google Fonts)
- `npm run lint` (prompts for interactive config)


------
https://chatgpt.com/codex/tasks/task_e_689c4900b6908328b482fd40cf003e4d