### PR TITLE
Fix async params usage in attraction page

### DIFF
--- a/app/attraction/[id]/page.tsx
+++ b/app/attraction/[id]/page.tsx
@@ -9,8 +9,13 @@ interface Attraction {
   longitude: number;
 }
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
-  const res = await fetch(`https://www.melivecode.com/api/attractions/${params.id}`, {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const res = await fetch(`https://www.melivecode.com/api/attractions/${id}`, {
     cache: "no-store",
   });
   const data = await res.json();
@@ -20,8 +25,13 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
   };
 }
 
-export default async function AttractionDetail({ params }: { params: { id: string } }) {
-  const res = await fetch(`https://www.melivecode.com/api/attractions/${params.id}`, {
+export default async function AttractionDetail({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const res = await fetch(`https://www.melivecode.com/api/attractions/${id}`, {
     cache: "no-store",
   });
   const data = await res.json();


### PR DESCRIPTION
## Summary
- await route params in metadata and detail page for attraction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_689c4b8da69c83288592268191c1146a